### PR TITLE
Have dates for each status

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ A document stored in the files table that contains information about a single st
   "id" : "<String>",
   "length" : "<Number>",
   "chunkSize" : "<Number>",
-  "createdAt" : "<Time>",
-  "startedAt" : "<Time>",
+  "completeDate" : "<Time>",
+  "incompleteDate" : "<Time>",
+  "deletedDate" : "<Time>",
   "sha256" : "<String>",
   "filename" : "<String>",
   "status" : "<String>",
@@ -72,8 +73,9 @@ A document stored in the files table that contains information about a single st
 | id | a unique ID for this document. |
 | length | the length of this stored file, in bytes. |
 | chunkSizeBytes | the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255KB (1024 * 255). |
-| createdAt | the date and time this file was added to RethinkDBFS. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
-| startedAt | the date and time this file upload was started to RethinkDBFS. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
+| completeDate | the date and time this files status was set to `Complete`. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
+| incompleteDate | the date and time this files status was set to `Incomplete`. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
+| deletedDate | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
 | sha256 | SHA256 checksum for this user file, computed from the file’s data, stored as a hex string (lowercase). |
 | filename | the name of this stored file; this does not need to be unique. |
 | status | Status may be "Complete" or "Incomplete" or "Deleted". |
@@ -264,10 +266,12 @@ After storing all chunk documents generated for the user file in the `chunks` ta
 | id | a unique ID for this document. |
 | length | the length of this stored file, in bytes. |
 | chunkSizeBytes | the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255KB (1024 * 255). |
-| createdAt | the date and time this file was added to RethinkDBFS. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
+| completeDate | the date and time this files status was set to `Complete`. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
+| incompleteDate | the date and time this files status was set to `Incomplete`. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
+| deletedDate | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
 | sha256 | SHA256 checksum for this user file, computed from the file’s data, stored as a hex string (lowercase). |
 | filename | the name of this stored file; this does not need to be unique. |
-| status | Status may be "Complete" or "Incomplete". |
+| status | Status may be "Complete" or "Incomplete" or "Deleted". |
 | metadata | any additional application data the user wishes to store. |
 
 If a user file contains no data, drivers MUST still create a files table document for it with length set to zero. Drivers MUST NOT create any empty chunks for this file.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For efficient execution of various RethinkDBFS operations the following indexes 
 An index on the `files` table:
 
 ```javascript
-r.table('<bucketName>_files').createIndex('status_filename_createdat', [r.row('status'), r.row('filename'), r.row('createdAt')])
+r.table('<bucketName>_files').createIndex('status_filename_createdat', [r.row('status'), r.row('filename'), r.row('finishedAt')])
 ```
 
 An index on the `chunks` table:

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ A document stored in the files table that contains information about a single st
   "id" : "<String>",
   "length" : "<Number>",
   "chunkSize" : "<Number>",
-  "completeDate" : "<Time>",
-  "incompleteDate" : "<Time>",
-  "deletedDate" : "<Time>",
+  "finishedAt" : "<Time>",
+  "startedAt" : "<Time>",
+  "deletedAt" : "<Time>",
   "sha256" : "<String>",
   "filename" : "<String>",
   "status" : "<String>",
@@ -73,9 +73,9 @@ A document stored in the files table that contains information about a single st
 | id | a unique ID for this document. |
 | length | the length of this stored file, in bytes. |
 | chunkSizeBytes | the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255KB (1024 * 255). |
-| completeDate | the date and time this files status was set to `Complete`. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
-| incompleteDate | the date and time this files status was set to `Incomplete`. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
-| deletedDate | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
+| finishedAt | the date and time this file finished writing to RethinkDBFS. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
+| startedAt | the date and time this file started writing to RethinkDBFS. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
+| deletedAt | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
 | sha256 | SHA256 checksum for this user file, computed from the file’s data, stored as a hex string (lowercase). |
 | filename | the name of this stored file; this does not need to be unique. |
 | status | Status may be "Complete" or "Incomplete" or "Deleted". |
@@ -266,9 +266,9 @@ After storing all chunk documents generated for the user file in the `chunks` ta
 | id | a unique ID for this document. |
 | length | the length of this stored file, in bytes. |
 | chunkSizeBytes | the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255KB (1024 * 255). |
-| completeDate | the date and time this files status was set to `Complete`. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
-| incompleteDate | the date and time this files status was set to `Incomplete`. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
-| deletedDate | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
+| finishedAt | the date and time this file finished writing to RethinkDBFS. The value of this field MUST be the datetime when the upload completed, not the datetime when it was begun. |
+| startedAt | the date and time this file started writing to RethinkDBFS. The value of this field MUST be the datetime when the upload started, not the datetime when it was finished. |
+| deletedAt | the date and time this files status was set to `Deleted`. The value of this field MUST be the datetime when file was marked `Deleted`. |
 | sha256 | SHA256 checksum for this user file, computed from the file’s data, stored as a hex string (lowercase). |
 | filename | the name of this stored file; this does not need to be unique. |
 | status | Status may be "Complete" or "Incomplete" or "Deleted". |


### PR DESCRIPTION
This uses a technique I've used in other apps. Anytime you change a status you set the appropriate `<status>Date` field to the current timestamp. Should solve this problem nicely and makes it easy to know which date is which.

@bchavez @danielmewes 
